### PR TITLE
#18759336 Sellers should be able to view  their statistics

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -36,7 +36,7 @@
 				"sequelize": "^6.37.3",
 				"socket.io": "^4.7.5",
 				"socket.io-client": "^4.7.5",
-				"stripe": "^15.6.0",
+				"stripe": "^15.7.0",
 				"uuid": "^9.0.1"
 			},
 			"devDependencies": {
@@ -9788,9 +9788,9 @@
 			}
 		},
 		"node_modules/stripe": {
-			"version": "15.6.0",
-			"resolved": "https://registry.npmjs.org/stripe/-/stripe-15.6.0.tgz",
-			"integrity": "sha512-ARG46eQHMmHspnDpj3QTAH8GyEqtE0nesbzpTtQDT/C9nHvOFYri3mIzHEzArzDcKX7HSleTu2VpYoDZIIH7nA==",
+			"version": "15.7.0",
+			"resolved": "https://registry.npmjs.org/stripe/-/stripe-15.7.0.tgz",
+			"integrity": "sha512-hTJhh0Gc+l+hj2vuzaFCh0T46l7793W3wg4J9Oyy3Wu+Ofswd0OgTS4XNt7G9XHJAyHpTmNRNbWgGwn73P4j7g==",
 			"dependencies": {
 				"@types/node": ">=8.1.0",
 				"qs": "^6.11.0"

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
 		"sequelize": "^6.37.3",
 		"socket.io": "^4.7.5",
 		"socket.io-client": "^4.7.5",
-		"stripe": "^15.6.0",
+		"stripe": "^15.7.0",
 		"uuid": "^9.0.1"
 	},
 	"jest": {
@@ -73,7 +73,8 @@
 			"src/helpers",
 			"src/documention/index.ts",
 			"/src/utils",
-			"src/middlewares"
+			"src/middlewares",
+			"src/services"
 		]
 	},
 	"devDependencies": {

--- a/src/__test__/stats.test.ts
+++ b/src/__test__/stats.test.ts
@@ -1,0 +1,113 @@
+import request from "supertest";
+import app from "../app";
+import database_models, {
+	connectionToDatabase,
+} from "../database/config/db.config";
+import { deleteTableData } from "../utils/database.utils";
+import {
+	expired_product,
+	new_product,
+	new_seller_user,
+	two_factor_authentication_data,
+} from "../mock/static";
+import { generateAccessToken } from "../helpers/security.helpers";
+import { sellerStatistics } from "../controllers/sellerStatisticsController";
+import productController from "../controllers/productController";
+import { read_function } from "../utils/db_methods";
+import { allRole } from "../controllers/roleController";
+import wishlistController from "../controllers/wishlistController";
+
+jest.mock("../utils/db_methods");
+const mockedReadFunction = read_function as jest.Mock;
+
+function logErrors(
+	err: { stack: any },
+	_req: any,
+	_res: any,
+	next: (arg0: any) => void,
+) {
+	console.log(err.stack);
+	next(err);
+}
+
+const Jest_request = request(app.use(logErrors));
+let seller_token: string;
+
+describe("STATISTICS API TEST", () => {
+	beforeAll(async () => {
+		await connectionToDatabase();
+	});
+
+	afterAll(async () => {
+		await deleteTableData(database_models.User, "users");
+		await deleteTableData(database_models.Product, "products");
+		await deleteTableData(database_models.Category, "categories");
+	});
+
+	it("it should  register a seller and return 201", async () => {
+		const { body } = await Jest_request.post("/api/v1/users/register")
+			.send(new_seller_user)
+			.expect(201);
+		expect(body.status).toStrictEqual("SUCCESS");
+		expect(body.message).toStrictEqual(
+			"Account Created successfully, Please Verify your Account",
+		);
+	});
+
+	it("it should authenticate the user and return 200", async () => {
+		const user = await database_models.User.findOne();
+		await database_models.User.update(
+			{ role: "13afd4f1-0bed-4a3b-8ad5-0978dabf8fcd" },
+			{
+				where: { id: user?.dataValues.id },
+			},
+		);
+		const authenticatetoken = generateAccessToken({
+			id: user?.dataValues.id as string,
+			role: "SELLER",
+			otp: two_factor_authentication_data.otp,
+		});
+		const { body } = await Jest_request.post(
+			`/api/v1/users/2fa/${authenticatetoken}`,
+		)
+			.send(two_factor_authentication_data)
+			.expect(200);
+
+		expect(body.message).toStrictEqual("Account authentication successfully!");
+		expect(body.data).toBeDefined();
+		seller_token = body.data;
+	});
+
+	it("Should list the seller's statistics and return 200", async () => {
+		const { body } = await Jest_request.get("/api/v1/stats")
+			.send()
+			.set("Authorization", `Bearer ${seller_token}`)
+			.expect(200);
+
+		expect(body.message).toStrictEqual("Here is your statistics");
+		expect(body.status).toStrictEqual("SUCCESS");
+	});
+
+	it("Should list the seller's statistics and return 200", async () => {
+		const { body } = await Jest_request.get("/api/v1/stats")
+			.send()
+			.set("Authorization", `Bearer ${seller_token}`)
+			.expect(200);
+
+		expect(body.message).toStrictEqual("Here is your statistics");
+		expect(body.status).toStrictEqual("SUCCESS");
+	});
+
+	it("should return 500 something went wrong", async () => {
+		const req: any = {};
+
+		const res: any = {
+			status: jest.fn().mockReturnThis(),
+			json: jest.fn(),
+		};
+
+		await sellerStatistics(req, res);
+
+		expect(res.status).toHaveBeenCalledWith(500);
+	});
+});

--- a/src/controllers/sellerStatisticsController.ts
+++ b/src/controllers/sellerStatisticsController.ts
@@ -1,0 +1,74 @@
+import { Request, Response } from "express";
+import { sendResponse } from "../utils/http.exception";
+import jwt, { JwtPayload } from "jsonwebtoken";
+import { Product } from "../database/models/product";
+
+export const sellerStatistics = async (req: Request, res: Response) => {
+	try {
+		const seller_token = req.headers.authorization?.split(" ")[1];
+		if (seller_token) {
+			const decoded_seller_token = jwt.decode(seller_token) as JwtPayload;
+			const { id } = decoded_seller_token;
+			if (id) {
+				const allProducts = await Product.findAndCountAll({
+					where: { sellerId: id },
+				});
+				const productSales = await Product.findAll({ where: { sellerId: id } });
+				let currentProductsValue = 0;
+				let loss = 0;
+				let numberOfExpiredProducts = 0;
+				let allProductsValue = 0;
+				let totalNumberOfProducts = 0;
+
+				productSales.forEach((product) => {
+					totalNumberOfProducts++;
+					const today = new Date();
+					const expired = product.dataValues.expiryDate < today;
+
+					if (expired) {
+						product.dataValues.isExpired = true;
+						loss += product.dataValues.price * product.dataValues.quantity;
+						numberOfExpiredProducts++;
+					} else {
+						currentProductsValue +=
+							product.dataValues.price * product.dataValues.quantity;
+					}
+				});
+
+				allProductsValue = productSales.reduce(
+					(acc, product) =>
+						acc + product.dataValues.price * product.dataValues.quantity,
+					0,
+				);
+
+				const totalRemainingProducts =
+					totalNumberOfProducts - numberOfExpiredProducts;
+
+				const data = {
+					totalProducts: allProducts.count,
+					allProductsValue: allProductsValue,
+					numberOfExpiredProducts: numberOfExpiredProducts,
+					loss: loss,
+					currentProductsValue: currentProductsValue,
+					totalRemainingProducts: totalRemainingProducts,
+				};
+
+				return sendResponse(
+					res,
+					200,
+					"SUCCESS",
+					"Here is your statistics",
+					data,
+				);
+			}
+		}
+	} catch (error) {
+		return sendResponse(
+			res,
+			500,
+			"SERVER ERROR",
+			"Internal server error",
+			(error as Error).message,
+		);
+	}
+};

--- a/src/documention/index.ts
+++ b/src/documention/index.ts
@@ -8,6 +8,7 @@ import { wishes } from "./wishlist";
 import { searches } from "./SearchProduct";
 import { cartsDocRoutes } from "./carts/carts";
 import { app_payments } from "./payments";
+import { stats } from "./stats";
 
 export default {
 	...basicInfo,
@@ -21,5 +22,6 @@ export default {
 		...wishes,
 		...cartsDocRoutes,
 		...app_payments,
+		...stats,
 	},
 };

--- a/src/documention/stats/index.ts
+++ b/src/documention/stats/index.ts
@@ -1,0 +1,20 @@
+import { responses } from "../responses";
+
+const read_statistics = {
+	tags: ["stats"],
+	security: [
+		{
+			bearerAuth: [],
+		},
+	],
+
+	sammary: "Here is your staticts",
+	description: "Seller statistics",
+	responses,
+};
+
+export const stats = {
+	"/api/v1/stats": {
+		get: read_statistics,
+	},
+};

--- a/src/mock/static.ts
+++ b/src/mock/static.ts
@@ -186,6 +186,14 @@ export const new_product = {
 	quantity: 356,
 	expiryDate: "2324-04-30T00:00:00.000Z",
 };
+export const expired_product = {
+	name: "BMW",
+	price: 49900,
+	images: [image_one_path, image_two_path, image_three_path, image_four_path],
+	discount: 100,
+	quantity: 356,
+	expiryDate: "2022-04-30T00:00:00.000Z",
+};
 export const new_update_product = {
 	name: "Ferrari",
 	price: 49900,

--- a/src/routes/index.ts
+++ b/src/routes/index.ts
@@ -8,6 +8,7 @@ import profileRouter from "./profileRouter";
 import wishesRouter from "./wishesRoutes";
 import cartRouter from "./cartRoutes";
 import paymentRouter from "./paymentsRoutes";
+import { statisticsRouter } from "./statisticsRoutes";
 
 const router = express.Router();
 
@@ -20,5 +21,6 @@ router.use("/", profileRouter);
 router.use("/wishes", wishesRouter);
 router.use("/carts", cartRouter);
 router.use("/payments", paymentRouter);
+router.use("/", statisticsRouter);
 
 export default router;

--- a/src/routes/statisticsRoutes.ts
+++ b/src/routes/statisticsRoutes.ts
@@ -1,0 +1,13 @@
+import express from "express";
+import { sellerStatistics } from "../controllers/sellerStatisticsController";
+
+import authenticate from "../middlewares/auth";
+
+export const statisticsRouter = express.Router();
+
+statisticsRouter.get(
+	"/stats",
+	authenticate.authenticateUser,
+	authenticate.isSeller,
+	sellerStatistics,
+);

--- a/src/types/model.ts
+++ b/src/types/model.ts
@@ -127,6 +127,8 @@ export interface ProductAttributes {
 	categoryId: string;
 	expiryDate: Date;
 	productStatus?: string;
+	isExpired?: boolean;
+	isSold?: boolean;
 }
 
 export type ProductCreationAttributes = Omit<ProductAttributes, "id">;


### PR DESCRIPTION
**_What does PR do?_**
- [ ] view seller's statistics

**Description**
    The seller should be able to view her/his products and related statistics
Endpoint:
1.  `api/v1/stats` Method => GET

**_How to test Locally_**
- Clone the repo
- Navigate to `feat-seller-statistics-187593362` and pull from it
- Run `npm install` to install the dependences
- Run `npm run migrate:reset` to initialize the migrations and seeders
- Run `npm run dev` to start the server and open the swagger or postman ...
- Login as a seller
- Hit `api/v1/stats` to view the seller's statistics and feel free to pack your seller and test more

Pivotal trackerId: 

     #187593362