### PR TITLE
fix(bug):fixing search product end points

### DIFF
--- a/src/__test__/product.test.ts
+++ b/src/__test__/product.test.ts
@@ -21,6 +21,7 @@ import {
 import { generateAccessToken } from "../helpers/security.helpers";
 import { read_function } from "../utils/db_methods";
 import { response } from "express";
+import searchProduct from "../controllers/searchProduct";
 
 jest.setTimeout(100000);
 
@@ -445,5 +446,15 @@ describe("PRODUCT API TEST", () => {
 
 		expect(body.status).toStrictEqual("SERVER ERROR");
 		expect(body.message).toStrictEqual("Something went wrong!");
+	});
+	it("it should return server error and return 500 when searching product", async () => {
+		const req: any = {};
+
+		const res: any = {
+			status: jest.fn().mockReturnThis(),
+			json: jest.fn(),
+		};
+		await searchProduct.search_product(req, res);
+		expect(res.status).toHaveBeenCalledWith(500);
 	});
 });

--- a/src/documention/SearchProduct/index.ts
+++ b/src/documention/SearchProduct/index.ts
@@ -9,13 +9,11 @@ const search = {
 				name: "name",
 				in: "query",
 				description: "Name of the item to search",
-				schema: { type: "string" },
 			},
 			{
 				name: "minPrice",
 				in: "query",
 				description: "price of the item to search",
-				schema: { type: "number" },
 			},
 			{
 				name: "maxPrice",

--- a/src/services/seachServices.ts
+++ b/src/services/seachServices.ts
@@ -14,23 +14,23 @@ const searchCondtion = async (queryParams: queryParamsAttribute) => {
 		};
 	} else if (minPrice) {
 		condition.price = {
-			[Op.gt]: [minPrice],
+			[Op.gte]: [minPrice],
 		};
 	} else if (maxPrice) {
 		condition.price = {
-			[Op.lt]: [maxPrice],
+			[Op.lte]: [maxPrice],
 		};
 	}
 
 	if (categoryName) {
 		const category = await findCategory(categoryName);
-		if (category) {
+		if (category?.length !== 0) {
 			condition.categoryId = {
 				[Op.eq]: category,
 			};
 		}
 	}
-	const whereClause = { [Op.or]: condition };
+	const whereClause = { [Op.and]: condition };
 	return whereClause;
 };
 export default searchCondtion;


### PR DESCRIPTION
FIX: search endpoints should return only product that match the querries

when you pass two querries like name and category name , it returning the product that do not have both criteria

ACTION: add if statements to check that product macth with criteria in querries.