### PR TITLE
User must not be verified after creating account

### DIFF
--- a/src/middlewares/passport.ts
+++ b/src/middlewares/passport.ts
@@ -59,7 +59,7 @@ passport.use(
 					lastName: req.body.lastName,
 					role: role?.dataValues.id as string,
 					isActive: true,
-					isVerified: true,
+					isVerified: false,
 					gender: req.body.gender || " ",
 					birthDate: req.body.birthDate || "01.01.1900",
 					phoneNumber: req.body.phoneNumber || "+250",


### PR DESCRIPTION
#### What PR do?

Fixing signup so that by default after registration User must not be verified and he/she should verify him/herself though an email sent after signing up

