### PR TITLE
[FIX]: Marking all notification read

### DIFF
--- a/src/__test__/server.test.ts
+++ b/src/__test__/server.test.ts
@@ -323,9 +323,9 @@ describe("SERVER API TEST", () => {
 			.send({ id: "97dcfe1e-0686-4876-808a-f3d3ec36c7ff" })
 			.set("Authorization", `Bearer ${buyer_token}`)
 			.expect(500);
-			expect(body.status).toStrictEqual("SERVER ERROR");
-			expect(body.message).toBe("Something went wrong!");
-		});
+		expect(body.status).toStrictEqual("SERVER ERROR");
+		expect(body.message).toBe("Something went wrong!");
+	});
 
 	it("should return 500 when something went wrong on getting all sales", async () => {
 		(read_function as jest.Mock).mockRejectedValueOnce(new Error("Test error"));

--- a/src/controllers/notificationController.ts
+++ b/src/controllers/notificationController.ts
@@ -137,7 +137,7 @@ export const mark_all_as_read = async (req: Request, res: Response) => {
 		const user = (req as any).user;
 		const userId = user?.id;
 
-		const condition = { where: { userId } };
+		const condition = { where: { userId, unread: true } };
 
 		const notifications: NotificationAttributes[] = await read_function<
 			NotificationAttributes[]

--- a/src/utils/socket.util.ts
+++ b/src/utils/socket.util.ts
@@ -52,7 +52,7 @@ export const config = (server: http.Server) => {
 			socket.emit("chat messages", messages);
 
 			const unreadNotifications = await DBNotification.findAll({
-				where: { userId, unread: true },
+				where: { userId },
 			});
 
 			socket.emit("notifications", unreadNotifications);


### PR DESCRIPTION
### Notification fix

1. Fixed when a user open the notification, he/she will be able to see all notification, either read or unread
2. And also when he mark all notification read, the one with status unread(true) should be updated only